### PR TITLE
Transfer to upload sftp files to Azure Blob Storage

### DIFF
--- a/airflow/providers/microsoft/azure/transfers/stfp_to_wasb.py
+++ b/airflow/providers/microsoft/azure/transfers/stfp_to_wasb.py
@@ -1,0 +1,157 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This module contains SFTP to Azure Blob Storage operator.
+"""
+import os
+from tempfile import NamedTemporaryFile
+from typing import Optional, Union
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+from airflow.providers.sftp.hooks.sftp import SFTPHook
+from airflow.utils.decorators import apply_defaults
+
+WILDCARD = "*"
+SFTP_FILE_PATH = "SFTP_FILE_PATH"
+BLOB_NAME = "BLOB_NAME"
+
+class STFPToWasbOperator(BaseOperator):
+    """
+    Transfer files to Azure Blob Storage from SFTP server.
+
+    :param sftp_source_path: The sftp remote path. This is the specified file path
+        for downloading the single file or multiple files from the SFTP server.
+        You can use only one wildcard within your path. The wildcard can appear
+        inside the path or at the end of the path.
+    :type sftp_source_path: str
+    :param container_name: Name of the container.
+    :type container_name: str
+    :param blob_name: Name of the blob.
+    :type blob_name: str
+    :param sftp_conn_id: The sftp connection id. The name or identifier for
+        establishing a connection to the SFTP server.
+    :type sftp_conn_id: str
+    :param wasb_conn_id: Reference to the wasb connection.
+    :type wasb_conn_id: str
+    :param load_options: Optional keyword arguments that
+        `WasbHook.load_file()` takes.
+    :type load_options: dict
+    :param move_object: When move object is True, the object is moved instead
+        of copied to the new location. This is the equivalent of a mv command
+        as opposed to a cp command.
+    :type move_object: bool
+    """
+    template_fields = ("sftp_source_path", "container_name", "blob_name")
+
+    @apply_defaults
+    def __init__(
+        self,
+        sftp_source_path: str,
+        container_name: str,
+        blob_name: str,
+        sftp_conn_id: str = "ssh_default",
+        wasb_conn_id: str = 'wasb_default',
+        load_options: dict = None,
+        move_object: bool = False,
+        *args,
+        **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.sftp_source_path = sftp_source_path
+        self.sftp_conn_id = sftp_conn_id
+        self.wasb_conn_id = wasb_conn_id
+        self.container_name = container_name
+        self.blob_name = blob_name
+        self.wasb_conn_id = wasb_conn_id
+        self.load_options = load_options if load_options is not None else {}
+        self.move_object = move_object
+
+    def execute(self, context):
+        (sftp_hook, sftp_files) = self.get_sftp_files_map()
+        uploaded_files = self.upload_wasb(sftp_hook, sftp_files)
+        self.sftp_move(sftp_hook, uploaded_files)
+
+    def get_sftp_files_map(self):
+        sftp_files = []
+        sftp_hook = SFTPHook(self.sftp_conn_id)
+
+        if WILDCARD in self.sftp_source_path:
+            self.check_wildcards_limit()
+
+            prefix, delimiter = self.sftp_source_path.split(WILDCARD, 1)
+            sftp_complete_path = os.path.dirname(prefix)
+
+            found_files, _, _ = sftp_hook.get_tree_map(
+                sftp_complete_path, prefix=prefix, delimiter=delimiter
+            )
+
+            self.log.info(
+                "Found %s files at sftp source path: %s",
+                str(len(found_files)),
+                self.sftp_source_path
+            )
+
+            for file in found_files:
+                future_blob_name = os.path.basename(file)
+                sftp_files.append({SFTP_FILE_PATH: file, BLOB_NAME: future_blob_name})
+
+        else:
+            sftp_files.append({SFTP_FILE_PATH: self.sftp_source_path, BLOB_NAME: self.blob_name})
+
+        return sftp_hook, sftp_files
+
+    def check_wildcards_limit(self):
+        total_wildcards = self.sftp_source_path.count(WILDCARD)
+        if total_wildcards > 1:
+            raise AirflowException(
+                "Only one wildcard '*' is allowed in sftp_source_path parameter. "
+                "Found {} in {}.".format(total_wildcards, self.sftp_source_path)
+            )
+
+    def upload_wasb(self, sftp_hook, sftp_files):
+        uploaded_files = []
+        wasb_hook = WasbHook(wasb_conn_id=self.wasb_conn_id)
+        for file in sftp_files:
+
+            with NamedTemporaryFile("w") as tmp:
+                sftp_hook.retrieve_file(file[SFTP_FILE_PATH], tmp.name)
+                self.log.info(
+                    'Uploading %s to wasb://%s as %s',
+                    file[SFTP_FILE_PATH],
+                    self.container_name,
+                    file[BLOB_NAME],
+                )
+                wasb_hook.load_file(tmp.name,
+                                    self.container_name,
+                                    file[BLOB_NAME],
+                                    **self.load_options)
+
+                uploaded_files.append(file[SFTP_FILE_PATH])
+
+        return uploaded_files
+
+    def sftp_move(self, sftp_hook, uploaded_files):
+        if self.move_object:
+            for sftp_file_path in uploaded_files:
+                self.log.info("Executing delete of %s", sftp_file_path)
+                sftp_hook.delete_file(sftp_file_path)
+
+

--- a/tests/providers/microsoft/azure/transfers/test_sftp_to_wasb.py
+++ b/tests/providers/microsoft/azure/transfers/test_sftp_to_wasb.py
@@ -1,0 +1,243 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+import datetime
+import unittest
+import os
+
+import mock
+
+from airflow import AirflowException
+from airflow.models.dag import DAG
+from airflow.providers.microsoft.azure.transfers.stfp_to_wasb import STFPToWasbOperator
+from airflow.providers.microsoft.azure.transfers.stfp_to_wasb import SFTP_FILE_PATH
+from airflow.providers.microsoft.azure.transfers.stfp_to_wasb import BLOB_NAME
+
+
+TASK_ID = "test-gcs-to-sftp-operator"
+WASB_CONN_ID = "wasb_default"
+SFTP_CONN_ID = "ssh_default"
+
+CONTAINER_NAME = "test-container"
+WILDCARD_PATH = "main_dir/*"
+WILDCARD_FILE_NAME = "main_dir/test_object*.json"
+SOURCE_OBJECT_NO_WILDCARD = "main_dir/test_object3.json"
+SOURCE_OBJECT_MULTIPLE_WILDCARDS = "main_dir/csv/*/test_*.csv"
+NEW_BLOB_NAME = "sponge-bob"
+EXPECTED_BLOB_NAME = "test_object3.json"
+
+
+# pylint: disable=unused-argument
+class TestSFTPToWasbOperator(unittest.TestCase):
+
+
+    def test_init(self):
+        operator = STFPToWasbOperator(
+            task_id=TASK_ID,
+            sftp_source_path=SOURCE_OBJECT_NO_WILDCARD,
+            sftp_conn_id=SFTP_CONN_ID,
+            container_name=CONTAINER_NAME,
+            blob_name=NEW_BLOB_NAME,
+            wasb_conn_id=WASB_CONN_ID,
+            move_object=False
+        )
+        self.assertEqual(operator.sftp_source_path, SOURCE_OBJECT_NO_WILDCARD)
+        self.assertEqual(operator.sftp_conn_id, SFTP_CONN_ID)
+        self.assertEqual(operator.container_name, CONTAINER_NAME)
+        self.assertEqual(operator.wasb_conn_id, WASB_CONN_ID)
+
+
+
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.WasbHook',
+                autospec=True)
+    def test_execute_more_than_one_wildcard_exception(self, mock_hook):
+        operator = STFPToWasbOperator(
+            task_id=TASK_ID,
+            sftp_source_path=SOURCE_OBJECT_MULTIPLE_WILDCARDS,
+            sftp_conn_id=SFTP_CONN_ID,
+            container_name=CONTAINER_NAME,
+            blob_name=BLOB_NAME,
+            wasb_conn_id=WASB_CONN_ID,
+            move_object=False
+        )
+        with self.assertRaises(AirflowException) as cm:
+            operator.check_wildcards_limit()
+
+        err = cm.exception
+        self.assertIn("Only one wildcard '*' is allowed", str(err))
+
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.WasbHook')
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.SFTPHook')
+    def test_get_sftp_files_map(self, sftp_hook, mock_hook):
+        sftp_hook.return_value.get_tree_map.return_value = [
+            [SOURCE_OBJECT_NO_WILDCARD, SOURCE_OBJECT_NO_WILDCARD],
+            [],
+            [],
+        ]
+        operator = STFPToWasbOperator(
+            task_id=TASK_ID,
+            sftp_source_path=WILDCARD_PATH,
+            sftp_conn_id=SFTP_CONN_ID,
+            container_name=CONTAINER_NAME,
+            blob_name=BLOB_NAME,
+            wasb_conn_id=WASB_CONN_ID,
+            move_object=False
+        )
+        _, files = operator.get_sftp_files_map()
+
+        sftp_hook.assert_called_once_with(SFTP_CONN_ID)
+
+        self.assertEquals(len(files), 2, "not matched at expected found files")
+        self.assertEqual(files[0][BLOB_NAME], EXPECTED_BLOB_NAME, "expected blob name not matched")
+
+
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.WasbHook')
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.SFTPHook')
+    def test_get_sftp_files_map(self, sftp_hook, mock_hook):
+        sftp_hook.return_value.get_tree_map.return_value = [
+            [SOURCE_OBJECT_NO_WILDCARD],
+            [],
+            [],
+        ]
+        operator = STFPToWasbOperator(
+            task_id=TASK_ID,
+            sftp_source_path=SOURCE_OBJECT_NO_WILDCARD,
+            sftp_conn_id=SFTP_CONN_ID,
+            container_name=CONTAINER_NAME,
+            blob_name=BLOB_NAME,
+            wasb_conn_id=WASB_CONN_ID,
+            move_object=True
+        )
+        _, files = operator.get_sftp_files_map()
+
+        sftp_hook.assert_called_once_with(SFTP_CONN_ID)
+
+        self.assertEquals(len(files), 1, "no matched at expected found files")
+        self.assertEqual(files[0][BLOB_NAME], BLOB_NAME, "expected blob name not matched")
+
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.WasbHook')
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.SFTPHook')
+    def test_upload_wasb(self, sftp_hook, mock_hook):
+
+
+        operator = STFPToWasbOperator(
+            task_id=TASK_ID,
+            sftp_source_path=SOURCE_OBJECT_NO_WILDCARD,
+            sftp_conn_id=SFTP_CONN_ID,
+            container_name=CONTAINER_NAME,
+            blob_name=BLOB_NAME,
+            wasb_conn_id=WASB_CONN_ID,
+            move_object=True
+        )
+
+        sftp_files = [{SFTP_FILE_PATH: SOURCE_OBJECT_NO_WILDCARD, BLOB_NAME: BLOB_NAME}]
+        files = operator.upload_wasb(sftp_hook, sftp_files)
+
+        sftp_hook.retrieve_file.assert_has_calls(
+            [
+                mock.call("main_dir/test_object3.json", mock.ANY)
+            ]
+        )
+
+        mock_hook.return_value.load_file.assert_called_once_with(
+            mock.ANY, CONTAINER_NAME, BLOB_NAME
+        )
+
+        self.assertEquals(len(files), 1, "no matched at expected uploaded files")
+
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.SFTPHook')
+    def test_sftp_move(self, sftp_hook):
+        sftp_mock = sftp_hook.return_value
+
+        operator = STFPToWasbOperator(
+            task_id=TASK_ID,
+            sftp_source_path=SOURCE_OBJECT_NO_WILDCARD,
+            sftp_conn_id=SFTP_CONN_ID,
+            container_name=CONTAINER_NAME,
+            blob_name=BLOB_NAME,
+            wasb_conn_id=WASB_CONN_ID,
+            move_object=True
+        )
+
+        sftp_file_paths = [SOURCE_OBJECT_NO_WILDCARD]
+        operator.sftp_move(sftp_mock, sftp_file_paths)
+
+        sftp_mock.delete_file.assert_has_calls(
+            [
+                mock.call(SOURCE_OBJECT_NO_WILDCARD)
+            ]
+        )
+
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.SFTPHook')
+    def test_no_sftp_move(self, sftp_hook):
+        sftp_mock = sftp_hook.return_value
+
+        operator = STFPToWasbOperator(
+            task_id=TASK_ID,
+            sftp_source_path=SOURCE_OBJECT_NO_WILDCARD,
+            sftp_conn_id=SFTP_CONN_ID,
+            container_name=CONTAINER_NAME,
+            blob_name=BLOB_NAME,
+            wasb_conn_id=WASB_CONN_ID,
+            move_object=False
+        )
+
+        sftp_file_paths = [SOURCE_OBJECT_NO_WILDCARD]
+        operator.sftp_move(sftp_mock, sftp_file_paths)
+
+        sftp_mock.delete_file.assert_not_called()
+
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.WasbHook')
+    @mock.patch('airflow.providers.microsoft.azure.transfers.stfp_to_wasb.SFTPHook')
+    def test_execute(self, sftp_hook, mock_hook):
+        sftp_hook.return_value.get_tree_map.return_value = [
+            [SOURCE_OBJECT_NO_WILDCARD],
+            [],
+            [],
+        ]
+
+        operator = STFPToWasbOperator(
+            task_id=TASK_ID,
+            sftp_source_path=WILDCARD_FILE_NAME,
+            sftp_conn_id=SFTP_CONN_ID,
+            container_name=CONTAINER_NAME,
+            blob_name=BLOB_NAME,
+            wasb_conn_id=WASB_CONN_ID,
+            move_object=False
+        )
+
+        operator.execute(None)
+
+        sftp_hook.return_value.get_tree_map.assert_called_with(
+            "main_dir", prefix="main_dir/test_object", delimiter=".json"
+        )
+
+        sftp_hook.return_value.retrieve_file.assert_has_calls(
+            [
+                mock.call(SOURCE_OBJECT_NO_WILDCARD, mock.ANY)
+            ]
+        )
+
+        mock_hook.return_value.load_file.assert_called_once_with(
+            mock.ANY, CONTAINER_NAME, os.path.basename(SOURCE_OBJECT_NO_WILDCARD)
+        )
+
+        sftp_hook.delete_file.assert_not_called()
+


### PR DESCRIPTION
sftp_transfer provides mechanism to extract file from a sftp path or files using a wildcard.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
